### PR TITLE
Add support for wallet configuration via private key

### DIFF
--- a/src/shared/chain.ts
+++ b/src/shared/chain.ts
@@ -9,10 +9,8 @@ import { error, trace } from "./log.js";
 import { TransactionReceipt } from "ethers";
 import { loadJson, saveJson } from "./fs.js";
 import { Contract, ethers, Signer, TransactionResponse } from "ethers";
-import { MnemonicWalletConfig, NetworkConfig, TargetConfig, WalletConfig } from "./config/index.js";
-import { ErrorFragment } from "ethers";
-import { EventFragment } from "ethers";
-
+import { MnemonicWalletConfig, PrivateKeyWalletConfig, NetworkConfig, TargetConfig, WalletConfig, WalletMnemonicType, WalletPrivateType } from "./config/index.js";
+import { ErrorFragment, EventFragment } from "ethers";
 
 interface Network {
   config: NetworkConfig,
@@ -58,7 +56,6 @@ export const setupTarget = async (ctx: Context, config: TargetConfig): Promise<T
   }
 }
 
-
 export const setupMnemonicWallet = (config: MnemonicWalletConfig): Signer => {
   let words: string = ''
 
@@ -79,14 +76,33 @@ export const setupMnemonicWallet = (config: MnemonicWalletConfig): Signer => {
   )
 }
 
+export const setupPrivateKeyWallet = (config: PrivateKeyWalletConfig): Signer => {
+  let key: string = ''
+
+  switch((typeof config.key)) {
+    case 'string':
+      key = config.key
+      break
+    case 'function':
+      key = config.key()
+      break
+  }
+
+  trace(`Setting up private key wallet with: ${key}`)
+
+  return new ethers.Wallet(key)
+}
+
 export const setupWallet = (walletConfig: WalletConfig) => {
   trace(`Setting up wallet of type: ${walletConfig.type}`)
 
   switch (walletConfig.type) {
     case 'mnemonic':
       return setupMnemonicWallet(walletConfig.config)
+    case 'private-key':
+      return setupPrivateKeyWallet(walletConfig.config)
     default:
-      error(`Unknown wallet type: ${walletConfig.type}`)
+      error(`Unknown wallet type: ${walletConfig}`)
   }
 }
 

--- a/src/shared/chain.ts
+++ b/src/shared/chain.ts
@@ -9,7 +9,7 @@ import { error, trace } from "./log.js";
 import { TransactionReceipt } from "ethers";
 import { loadJson, saveJson } from "./fs.js";
 import { Contract, ethers, Signer, TransactionResponse } from "ethers";
-import { MnemonicWalletConfig, PrivateKeyWalletConfig, NetworkConfig, TargetConfig, WalletConfig, WalletMnemonicType, WalletPrivateType } from "./config/index.js";
+import { MnemonicWalletConfig, PrivateKeyWalletConfig, NetworkConfig, TargetConfig, WalletConfig } from "./config/index.js";
 import { ErrorFragment, EventFragment } from "ethers";
 
 interface Network {

--- a/src/shared/config/index.ts
+++ b/src/shared/config/index.ts
@@ -16,10 +16,23 @@ export interface MnemonicWalletConfig {
   index: number,
 }
 
-export type WalletConfig = {
-  type: 'mnemonic',
-  config: MnemonicWalletConfig,
+export interface PrivateKeyWalletConfig {
+  key: string | Function
 }
+
+export type ValidWalletType = 'mnemonic' | 'private-key'
+
+export interface WalletMnemonicType {
+  type: 'mnemonic'
+  config: MnemonicWalletConfig
+}
+
+export interface WalletPrivateType {
+  type: 'private-key'
+  config: PrivateKeyWalletConfig
+}
+
+export type WalletConfig = WalletMnemonicType | WalletPrivateType
 
 export interface NetworkConfig {
   rpcUrl: string | Function,
@@ -144,14 +157,19 @@ export const sanitizeConfig = (config: GemforgeConfig) => {
     throwError(`No value found`, 'wallets')
   }
   walletNames.forEach(name => {
-    ensure(config, `wallets.${name}.type`, (v: any) => ['mnemonic'].indexOf(v) >= 0, 'Invalid wallet type')
+    ensure(config, `wallets.${name}.type`, (v: any) => ['mnemonic', 'private-key'].indexOf(v) >= 0, 'Invalid wallet type')
 
     ensureIsSet(config, `wallets.${name}.config`)
 
-    const type = get(config, `wallets.${name}.type`)
+    const type = get(config, `wallets.${name}.type`) as ValidWalletType
     switch (type) {
       case 'mnemonic': {
         ensureIsType(config, `wallets.${name}.config.words`, ['string', 'function'])
+        ensureIsType(config, `wallets.${name}.config.index`, ['number'])
+        break
+      }
+      case 'private-key': {
+        ensureIsType(config, `wallets.${name}.config.key`, ['string', 'function'])
         break
       }
     }

--- a/src/shared/config/index.ts
+++ b/src/shared/config/index.ts
@@ -27,12 +27,12 @@ export interface WalletMnemonicType {
   config: MnemonicWalletConfig
 }
 
-export interface WalletPrivateType {
+export interface WalletPrivateKeyType {
   type: 'private-key'
   config: PrivateKeyWalletConfig
 }
 
-export type WalletConfig = WalletMnemonicType | WalletPrivateType
+export type WalletConfig = WalletMnemonicType | WalletPrivateKeyType
 
 export interface NetworkConfig {
   rpcUrl: string | Function,

--- a/src/shared/config/v1.ts
+++ b/src/shared/config/v1.ts
@@ -19,12 +19,12 @@ export interface WalletMnemonicType {
   config: MnemonicWalletConfig
 }
 
-export interface WalletPrivateType {
+export interface WalletPrivateKeyType {
   type: 'private-key'
   config: PrivateKeyWalletConfig
 }
 
-export type WalletConfig = WalletMnemonicType | WalletPrivateType
+export type WalletConfig = WalletMnemonicType | WalletPrivateKeyType
 
 interface NetworkConfig {
   rpcUrl: string | Function,

--- a/src/shared/config/v1.ts
+++ b/src/shared/config/v1.ts
@@ -3,15 +3,28 @@ import { ensure, ensureArray, ensureBool, ensureIsSet, ensureIsType, throwError 
 // @ts-ignore
 import spdxLicenseIds from 'spdx-license-ids' assert { type: "json" }
 
-interface MnemonicWalletConfig {
+export interface MnemonicWalletConfig {
   words: string | Function,
   index: number,
 }
 
-type WalletConfig = {
-  type: 'mnemonic',
-  config: MnemonicWalletConfig,
+export interface PrivateKeyWalletConfig {
+  key: string | Function
 }
+
+export type ValidWalletType = 'mnemonic' | 'private-key'
+
+export interface WalletMnemonicType {
+  type: 'mnemonic'
+  config: MnemonicWalletConfig
+}
+
+export interface WalletPrivateType {
+  type: 'private-key'
+  config: PrivateKeyWalletConfig
+}
+
+export type WalletConfig = WalletMnemonicType | WalletPrivateType
 
 interface NetworkConfig {
   rpcUrl: string | Function,
@@ -107,14 +120,19 @@ export const sanitizeConfigV1 = (config: GemforgeConfigV1) => {
     throwError(`No value found`, 'wallets')
   }
   walletNames.forEach(name => {
-    ensure(config, `wallets.${name}.type`, (v: any) => ['mnemonic'].indexOf(v) >= 0, 'Invalid wallet type')
+    ensure(config, `wallets.${name}.type`, (v: any) => ['mnemonic', 'private-key'].indexOf(v) >= 0, 'Invalid wallet type')
 
     ensureIsSet(config, `wallets.${name}.config`)
 
-    const type = get(config, `wallets.${name}.type`)
+    const type = get(config, `wallets.${name}.type`) as ValidWalletType
     switch (type) {
       case 'mnemonic': {
         ensureIsType(config, `wallets.${name}.config.words`, ['string', 'function'])
+        ensureIsType(config, `wallets.${name}.config.index`, ['number'])
+        break
+      }
+      case 'private-key': {
+        ensureIsType(config, `wallets.${name}.config.key`, ['string', 'function'])
         break
       }
     }


### PR DESCRIPTION
Enables the wallet configuration to be done by only providing the private key. 

Issue: #29 

Here is how an example configuration in the `gemforge.config.cjs` would look like:

```
  // Wallets to use for deployment
  wallets: {
    ...
    walletPK: {
      type: "private-key",
      config: {
        key: process.env.PRIVATE_KEY_ACC20,
      },
    },
  },
```