### PR TITLE
bugfix: all methods should be external in the proxy interface (#44)

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -58,7 +58,7 @@ export const command = () =>
         __CUSTOM_IMPORTS__: customImportsStr,
         __METHODS__: facets
           .reduce((m, f) => m.concat(f.functions), [] as any[])
-          .map(f => `${f.signature};`)
+          .map(f => `${f.signature};`.replace(" public", " external"))
           .join('\n')
       })
 


### PR DESCRIPTION
When generating the `IDiamondProxy` interface, all the methods must be external ( #44 ) for solidity compilation to be successful. 