### PR TITLE
feat: manual diamondcut calls for upgrades

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -229,12 +229,12 @@ export const command = () =>
             })
             skipPostDeployHook = true
           } else {
-            if (t.upgrades?.manualCut) {
-              notice('Outputting upgrade tx params so that you can do the upgrade manually...\n\n')
+            if (!isNewDeployment && t.upgrades?.manualCut) {
+              notice('Outputting upgrade tx params so that you can do the upgrade manually...\n')
               notice(`================================================================================\n`)
               notice(`Diamond: ${proxyInterface!.address}\n`)
               notice(`Tx data: ${proxyInterface!.contract.interface.encodeFunctionData('diamondCut', [cuts, initContractAddress, initData])}\n`)
-              notice(`================================================================================\n\n`)
+              notice(`================================================================================\n`)
             } else {
               await callDiamondCut(proxyInterface!, cuts, initContractAddress, initData)
             }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -3,7 +3,7 @@ import { OnChainContract, Target, clearDeploymentRecorder, deployContract, deplo
 import { Context, getContext } from '../shared/context.js'
 import { FacetCut, FacetCutAction, getFinalizedFacetCuts, resolveClean, resolveUpgrade } from '../shared/diamond.js'
 import { $, loadJson, saveJson } from '../shared/fs.js'
-import { error, info, trace, warn } from '../shared/log.js'
+import { error, info, notice, trace, warn } from '../shared/log.js'
 import { createCommand, loadExistingDeploymentAndLog, loadFacetArtifactsAndLog, logSuccess } from './common.js'
 
 export const command = () =>
@@ -229,7 +229,15 @@ export const command = () =>
             })
             skipPostDeployHook = true
           } else {
-            await callDiamondCut(proxyInterface!, cuts, initContractAddress, initData)
+            if (t.upgrades?.manualCut) {
+              notice('Outputting upgrade tx params so that you can do the upgrade manually...\n\n')
+              notice(`================================================================================\n`)
+              notice(`Diamond: ${proxyInterface!.address}\n`)
+              notice(`Tx data: ${proxyInterface!.contract.interface.encodeFunctionData('diamondCut', [cuts, initContractAddress, initData])}\n`)
+              notice(`================================================================================\n\n`)
+            } else {
+              await callDiamondCut(proxyInterface!, cuts, initContractAddress, initData)
+            }
           }
         }
       }

--- a/src/shared/config/index.ts
+++ b/src/shared/config/index.ts
@@ -50,11 +50,16 @@ export interface NetworkConfig {
   },
 }
 
+export interface TargetUpgradeConfig {
+  manualCut: boolean,
+}
+
 export interface TargetConfig {
   network: string,
   wallet: string,
   initArgs: any[],
   create3Salt?: string,
+  upgrades?: TargetUpgradeConfig,
 }
 
 export interface GemforgeConfig {
@@ -242,6 +247,10 @@ export const sanitizeConfig = (config: GemforgeConfig) => {
       },
       'Invalid CREATE3 salt'
     )
+    ensureIsType(config, `targets.${name}.upgrades`, ['undefined', 'object'])
+    if (config.targets[name].upgrades) {
+      ensureIsType(config, `targets.${name}.upgrades.manualCut`, ['boolean'])
+    }
   })
 }
 

--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -11,6 +11,10 @@ export const trace = (message: string) => {
     console.log(chalk.gray(prefixLogMsg(message)))
   }
 }
+export const notice = (message: string) => {
+  if (disabled) return
+  console.log(chalk.cyanBright(prefixLogMsg(message)))
+}
 export const info = (message: string) => {
   if (disabled) return
   console.log(chalk.cyan(prefixLogMsg(message)))

--- a/test/common-deploy-steps.ts
+++ b/test/common-deploy-steps.ts
@@ -739,6 +739,14 @@ export const addDeployTestSteps = ({
   describe('can handle upgrade only output tx params without sending tx', () => {
     beforeEach(async () => {
       cwd = setupFolderCallback()
+      
+      await updateConfigFile(join(cwd, 'gemforge.config.cjs'), (cfg: GemforgeConfig) => {
+        cfg.targets.local.upgrades = {
+          manualCut: true
+        }
+        return cfg
+      })
+
       expect(cli('build', { cwd, verbose: false }).success).to.be.true
       expect(cli('deploy', 'local', { cwd, verbose: false }).success).to.be.true
 
@@ -798,13 +806,6 @@ export const addDeployTestSteps = ({
       `)
 
       expect(cli('build', { cwd, verbose: false }).success).to.be.true
-
-      await updateConfigFile(join(cwd, 'gemforge.config.cjs'), (cfg: GemforgeConfig) => {
-        cfg.targets.local.upgrades = {
-          manualCut: true
-        }
-        return cfg
-      })
     })
 
     it('and will output the tx params', async () => {      

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -4,7 +4,7 @@ import { basename, dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from 'node:url'
 import chai, { expect } from "chai"
 import chaiAsPromised from 'chai-as-promised'
-import { Contract, Fragment, TransactionResponse, ethers } from "ethers"
+import { Contract, Fragment, Signer, TransactionResponse, ethers } from "ethers"
 import { glob } from "glob"
 import get from "lodash.get"
 import tmp from 'tmp'
@@ -127,6 +127,7 @@ export const assertFileMatchesCustomTemplate = (jsFilePath: string, templatePath
 
 export interface LoadedContract {
   contract: Contract,
+  signer: Signer,
   walletAddress: string,
 }
 
@@ -209,6 +210,7 @@ export const loadDiamondContract = async (cwd: string, abiOverride?: string[], a
 
   return {
     contract: factory.attach(address!) as Contract,
+    signer,
     walletAddress: await signer.getAddress(),
   }
 }


### PR DESCRIPTION
Adds the ability to have the `diamondCut()` call for upgrades (not new deployments) to be done manually. 

This is useful if, after deployment, you assign the ownership of the diamond to a multisig (e.g Gnosis SAFE) or something similar, where cli-based hot wallet deployments are not possible.

In future we may implement an elegant solution, but for now this gets Gemforge to output the parameters needed to construct the upgrade transaction manually.

Config:

```js
  targets: {
    local: {
      network: 'local',
      wallet: 'wallet1',
      initArgs: [],
      upgrades: {
        manualCut: true
      }
    },
  },
```

Output will look something like:

```shell
GEMFORGE: Outputting upgrade tx params and skipping actual tx call...

GEMFORGE: ================================================================================

GEMFORGE: Diamond: 0x3351cb6fD12655854DDAa85b0D9857d3e20a1310

GEMFORGE: Tx data: 0x1f931c1c000000000000000000000000000000000000000000000000000000000000006000000000000000000000000049fd2be640db2910c2fab69bb8531ab6e76127ff00000000000000000000000000000000000000000000000000000000000002400000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000001000000000000000000000000007a9ec1d04904907de0ed7b6839ccdd59c3716ac9000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000002e1bb9b63000000000000000000000000000000000000000000000000000000004d2c097d000000000000000000000000000000000000000000000000000000000000000000000000000000007a9ec1d04904907de0ed7b6839ccdd59c3716ac90000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000000029ec066d20000000000000000000000000000000000000000000000000000000037f30a8e000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004e1c7392a00000000000000000000000000000000000000000000000000000000

GEMFORGE: ================================================================================
```